### PR TITLE
update header file for Qt5

### DIFF
--- a/src/http/Server.cpp
+++ b/src/http/Server.cpp
@@ -18,7 +18,7 @@
 #include "crypto/Crypto.h"
 #include <QtCore/QHash>
 #include <QtCore/QCryptographicHash>
-#include <QtGui/QMessageBox>
+#include <QtWidgets/QMessageBox>
 #include <QEventLoop>
 
 using namespace KeepassHttpProtocol;


### PR DESCRIPTION
The header file for QMessageBox has been moved from "QtGui" to "QtWidgets"